### PR TITLE
Add OnGatewayInit interface so the afterInit doesn't come out of nowhere

### DIFF
--- a/src/pokers/pokers.gateway.ts
+++ b/src/pokers/pokers.gateway.ts
@@ -2,13 +2,14 @@ import {
   WebSocketGateway,
   SubscribeMessage,
   WebSocketServer,
+  OnGatewayInit,
 } from '@nestjs/websockets';
 import { PokersService } from './pokers.service';
 import { Server, Socket } from 'socket.io';
 import { PointsService } from '../points/points.service';
 
 @WebSocketGateway({ namespace: '/pokers' })
-export class PokersGateway {
+export class PokersGateway implements OnGatewayInit {
   @WebSocketServer() server: Server;
 
   constructor(private readonly pokersService: PokersService) {}


### PR DESCRIPTION
My IDE whined about the `afterInit` function not being used.