### PR TITLE
Only group voter names if the initial vote and the current vote are equal

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -138,8 +138,8 @@
                                 <i :class="['fas','fa-mug-hot']" v-if="vote.currentValue === 'coffee'"></i>
                                 {{ vote.currentValue }}
                                 <div class="vote-names"
-									 v-if="groupedVoterNames && groupedVoterNames[vote.currentValue]">
-                                {{ groupedVoterNames[vote.currentValue] && groupedVoterNames[vote.currentValue].join(', ') }}
+									 v-if="getGroupedVoteNames(vote)">
+                                {{ getGroupedVoteNames(vote).join(', ') }}
                             </div>
                             </button>
 
@@ -434,6 +434,13 @@
 			getFromURL(key) {
 				return new URLSearchParams(window.location.search.substring(1)).get(key)
 			},
+			getGroupedVoteNames( vote ) {
+				if ( ! this.groupedVoterNames ) {
+					return [];
+				}
+				const voteGroupKey = vote.initialValue + "/" + vote.currentValue;
+				return this.groupedVoterNames[ voteGroupKey ];
+			}
 		},
 		computed: {
 			unvotedNames() {

--- a/src/pokers/pokers.service.ts
+++ b/src/pokers/pokers.service.ts
@@ -311,9 +311,10 @@ export class PokersService {
 				voteCount: votes.length,
 				votes,
 				groupedVoterNames: voted.reduce( ( accumulator, client: Client ) => {
-					const vote                       = this.getRoom( poker ).getCurrentVote( client.id );
-					accumulator[ vote.currentValue ] = accumulator[ vote.currentValue ] || [];
-					accumulator[ vote.currentValue ].push( client.name );
+					const vote                  = this.getRoom( poker ).getCurrentVote( client.id );
+					const voteGroupKey: string  = vote.initialValue + "/" + vote.currentValue;
+					accumulator[ voteGroupKey ] = accumulator[ voteGroupKey ] || [];
+					accumulator[ voteGroupKey ].push( client.name );
 					return accumulator;
 				}, {} ),
 			};


### PR DESCRIPTION
If a user changed their vote from 3 to 5, you can't tell who it was. This is because both names will be linked to both 5 votes.
![image](https://user-images.githubusercontent.com/5352634/101282727-02d5e280-37d7-11eb-8fa6-b5c72af30793.png)

With this PR, you can
![image](https://user-images.githubusercontent.com/5352634/101282770-3d3f7f80-37d7-11eb-91b3-f57f3ad3f477.png)
![image](https://user-images.githubusercontent.com/5352634/101282790-606a2f00-37d7-11eb-9351-060fb6ade46d.png)

If both users switch from 3 to 5, both names will be shown on hover.
![image](https://user-images.githubusercontent.com/5352634/101282813-7972e000-37d7-11eb-953c-1d3d7d51b0ae.png)

