### PR TITLE
Sort non-numeric votes

### DIFF
--- a/frontend/src/services/store.js
+++ b/frontend/src/services/store.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import { sortVotes } from "./voteSorting.ts";
 
 Vue.use( Vuex );
 
@@ -61,9 +62,7 @@ export default new Vuex.Store( {
 			state.votingSystem = data.votingSystem;
 		},
 		SOCKET_VOTES( state, data ) {
-			const votes = data.votes.sort( ( a, b ) => a.currentValue - b.currentValue ) || [];
-
-			state.votes = votes;
+			state.votes = sortVotes( data.votes, state.points );
 			state.votesRevealed = data.votesRevealed;
 			state.voteCount = data.voteCount;
 			state.votedNames = data.votedNames || [];

--- a/frontend/src/services/voteSorting.ts
+++ b/frontend/src/services/voteSorting.ts
@@ -1,0 +1,45 @@
+/**
+ * Sorts a list of cast votes in the same order as the list of available points.
+ *
+ * @param {Vote[]} votes A list of cast votes to sort.
+ * @param {(string|number)[]} availablePoints An array of available points to cast.
+ *
+ * @returns {Vote[]} A sorted vote array.
+ */
+export function sortVotes( votes, availablePoints ) {
+	// If we don't have available points yet, return early.
+	if ( ! availablePoints.length ) {
+		return votes;
+	}
+
+	/*
+	 * Create a map of the index of each available point.
+	 * For example:
+	 * {
+	 *    0: 0
+	 *    0.5: 1
+	 *    1: 2
+	 *    2: 3
+	 *    3: 4
+	 *    5: 5
+	 *    8: 6
+	 *    13: 7
+	 *    21: 8
+	 *    100: 9
+	 *    "?": 10
+	 *    coffee: 11
+	 * }
+	 */
+	const orderedPoints = availablePoints.reduce( ( acc, currentValue, index ) => {
+		return { ...acc, [ currentValue ]: index };
+	}, {} );
+
+	return votes.sort( ( a, b ) => {
+		// If the votes are equal, sort based on the initial vote.
+		if ( a.currentValue === b.currentValue ) {
+			return orderedPoints[ a.initialValue ] - orderedPoints[ b.initialValue ];
+		}
+
+		return orderedPoints[ a.currentValue ] - orderedPoints[ b.currentValue ];
+	} );
+}

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       "ts"
     ],
     "rootDir": "./",
-    "testRegex": ".*\\.spec\\.ts$",
+    "testRegex": ".*\\.spec\\.(t|j)s$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/tests/frontend/services/voteSorting.spec.ts
+++ b/tests/frontend/services/voteSorting.spec.ts
@@ -1,0 +1,140 @@
+import { Vote } from "../../../backend/src/services/PokerStoryHandler";
+import { sortVotes } from "../../../frontend/src/services/voteSorting";
+
+describe( "the voteSorting", () => {
+	describe( "sortVotes function", () => {
+		/**
+		 * Creates a test double vote object.
+		 *
+		 * @param {number | string} initialValue The initial vote value.
+		 * @param {number | string} currentValue The current vote value, uses the initial value by default.
+		 *
+		 * @returns {Partial<Vote>} The vote test double.
+		 */
+		const getVote = ( initialValue: number | string, currentValue?: number | string ): Partial<Vote> => {
+			return {
+				initialValue,
+				currentValue: currentValue || initialValue,
+			};
+		};
+
+		it.each(
+			[
+				{
+					description: "All numeric votes and points",
+					votes: [
+						getVote( 1 ),
+						getVote( 5 ),
+						getVote( 2 ),
+					],
+					availablePoints: [ 1, 2, 3, 4, 5 ],
+					expected: [
+						getVote( 1 ),
+						getVote( 2 ),
+						getVote( 5 ),
+					],
+				},
+				{
+					description: "Already ordered votes",
+					votes: [
+						getVote( 1 ),
+						getVote( 2 ),
+						getVote( 3 ),
+					],
+					availablePoints: [ 1, 2, 3, "four", "five" ],
+					expected: [
+						getVote( 1 ),
+						getVote( 2 ),
+						getVote( 3 ),
+					],
+				},
+				{
+					description: "String and numeric votes",
+					votes: [
+						getVote( 1 ),
+						getVote( "four" ),
+						getVote( 3 ),
+					],
+					availablePoints: [ 1, 2, 3, "four", 5 ],
+					expected: [
+						getVote( 1 ),
+						getVote( 3 ),
+						getVote( "four" ),
+					],
+				},
+				{
+					description: "Order on initial vote if the current votes are equal",
+					votes: [
+						getVote( 5, 3 ),
+						getVote( 2, 3 ),
+						getVote( 3 ),
+					],
+					availablePoints: [ 1, 2, 3, 4, 5 ],
+					expected: [
+						getVote( 2, 3 ),
+						getVote( 3 ),
+						getVote( 5, 3 ),
+					],
+				},
+				{
+					description: "String and numeric votes combined",
+					votes: [
+						getVote( "three" ),
+						getVote( 2, "three" ),
+						getVote( 1 ),
+					],
+					availablePoints: [ 1, 2, "three", 4, 5 ],
+					expected: [
+						getVote( 1 ),
+						getVote( 2, "three" ),
+						getVote( "three" ),
+					],
+				},
+				{
+					description: "No available points - don't sort",
+					votes: [
+						getVote( "three" ),
+						getVote( 2, "three" ),
+						getVote( 1 ),
+					],
+					availablePoints: [],
+					expected: [
+						getVote( "three" ),
+						getVote( 2, "three" ),
+						getVote( 1 ),
+					],
+				},
+				{
+					description: "No available points and no votes - don't sort",
+					votes: [],
+					availablePoints: [],
+					expected: [],
+				},
+				{
+					description: "No votes - don't sort",
+					votes: [],
+					availablePoints: [ 1, 2, 3 ],
+					expected: [],
+				},
+				{
+					description: "Illegal point value used - don't sort",
+					votes: [
+						getVote( 2 ),
+						getVote( "illegal" ),
+						getVote( 1 ),
+					],
+					availablePoints: [ 1, 2 ],
+					expected: [
+						getVote( 2 ),
+						getVote( "illegal" ),
+						getVote( 1 ),
+					],
+				},
+			],
+		)( "sorts votes: %s", ( { votes, availablePoints, expected } ) => {
+			const actual = sortVotes( votes, availablePoints );
+
+			expect( actual ).toEqual( expected );
+		} );
+	} );
+} );


### PR DESCRIPTION
fixes #79 

Some relevant choices:
- I kept the sorting client-side.
- If the current vote values are the same, I sort on the initial value. It felt more natural/logical to me when testing.
- I made the voteSorting service a TS file, so it can be unittested. The current Jest setup couldn't deal with ES6 .js files.
- I added a `description` key to the Jest each table. They're not used in the test, but are shown when a test case fails. This helps with debugging